### PR TITLE
Match url to old docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ This repo contains all the documentation for all Wild Me products, including Wil
 
 ## Planned changes
 The documentation will eventually support:
-- TODO #12 release versions to match product functionality
-- TODO #14 language support
-- TODO #15 generated API documentation
+- #12 release versions to match product functionality
+- #14 language support
+- #15 generated API documentation
 
 ## Local Setup
 1. Install the prereqs:
@@ -26,4 +26,4 @@ To build:
 3. Files will be in `docs/_build/product-docs/en/html/`
 
 ## Contribute to docs
-TODO #11
+#11 TBD

--- a/README.md
+++ b/README.md
@@ -1,14 +1,29 @@
-- clone wildme-docs
+# Wild Me Docs
+This repo contains all the documentation for all Wild Me products, including Wildbook, Scout, and Codex. Documentation is published with every accepted PR.
+
+## Planned changes
+The documentation will eventually support:
+- TODO #12 release versions to match product functionality
+- TODO #14 language support
+- TODO #15 generated API documentation
+
+## Local Setup
+1. Install the prereqs:
 - install sphinx
 - install [sphinx-book-there](https://sphinx-book-theme.readthedocs.io/en/stable/tutorials/get-started.html): `pip install sphinx-book-theme`
 - install [myst-parser](https://www.sphinx-doc.org/en/master/usage/markdown.html) (used by sphinx markdown extension): `pip install myst-parser`
+2. Clone the `wildme-docs` repo: `git clone https://github.com/WildMeOrg/wildme-docs.git`
 
-to build, from inside the `docs/` directory:
-```
-python -m venv .venv
-source .venv/bin/activate
-make html
-```
+## Build locally
+To build:
+1. `cd` to the `docs` directory:
+2. Run the following commands:
+    ```
+    python -m venv .venv
+    source .venv/bin/activate
+    make html
+    ```
+3. Files will be in `docs/_build/product-docs/en/html/`
 
-files will be in `docs/_build/html/`.
-
+## Contribute to docs
+TODO #11

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -6,7 +6,7 @@
 SPHINXOPTS    ?=
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = .
-BUILDDIR      = _build
+BUILDDIR      = _build/product-docs/en
 
 # Put it first so that "make" without argument is like "make help".
 help:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,5 +24,3 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', '.venv']
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
 html_theme = 'sphinx_book_theme'
-html_static_path = ['_static']
-html_baseurl = '/product-docs/en/'


### PR DESCRIPTION
URL needs to contain `/product-docs/en` to match old doc system and preserve in-product links

also include some cleanup of `conf.py` and `readme`